### PR TITLE
Fix unintialized timeval in OT extension

### DIFF
--- a/src/ot-based/ot-psi.cpp
+++ b/src/ot-based/ot-psi.cpp
@@ -425,6 +425,10 @@ void oprg_client(uint8_t* hash_table, uint32_t nbins, uint32_t neles, uint32_t* 
 	KKOTExtRcv* receiver;
 	timeval t_start, t_end;
 
+	if(DETAILED_TIMINGS) {
+		gettimeofday(&t_start, NULL);
+	}
+
 #ifndef BATCH
 	cout << "Client: bins = " << nbins << ", elebitlen = " << elebitlen << " and maskbitlen = " <<
 			maskbitlen << " and performs " << nbins << " OTs" << endl;
@@ -480,6 +484,10 @@ void oprg_server(uint8_t* hash_table, uint32_t nbins, uint32_t totaleles, uint32
 	KKOTExtSnd* sender;
 	uint32_t maskbytelen = ceil_divide(maskbitlen, 8);
 	timeval t_start, t_end;
+
+	if(DETAILED_TIMINGS) {
+		gettimeofday(&t_start, NULL);
+	}
 
 #ifndef BATCH
 	cout << "Server: bins = " << nbins << ", elebitlen = " << elebitlen << " and maskbitlen = " <<


### PR DESCRIPTION
The timeval start value *t_start* was not initialized *oprg_server* and *oprg_client*, causing the displayed value of OT extension execution time to be a random double when using the `-t` flag.

Before fix:

```shell
Time for OT extension:		-2205237497622492.50 ms
Time for OT extension:		1657620414014.78 ms
```

After initialization:

```shell
Time for OT extension:		341.72 ms
Time for OT extension:		462.07 ms
```