### PR TITLE
Fix grammar: 'a experimental' → 'an experimental' #HSFDPMUW

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This code is provided as an experimental implementation for testing purposes and
 ### Requirements
 ---
 
-* A **Linux distribution** of your choice (the code was developed and tested with recent versions of [Ubuntu](https://www.ubuntu.com/)).
+* A **Linux distribution** of your choice (the code was developed and tested with recent versions of [Ubuntu](http://www.ubuntu.com/)).
 * **Required packages:**
   * [`g++`](https://packages.debian.org/testing/g++)
   * [`make`](https://packages.debian.org/testing/make)
@@ -40,7 +40,7 @@ This code is provided as an experimental implementation for testing purposes and
 
 3. Call `make` in the root directory to compile all dependencies, tests, and examples and create the executables: **psi.exe** (used for benchmarking) and **demo.exe** (a small demonstrator for intersecting email addresses).
 
-Please note that downloading this project as ZIP file will yield compilation errors, since the Miracl library is included as external project. To solve this, download the Miracl sources in commit version `cff161b` (found at [Miracl commit cff161b](https://github.com/CertiVox/Miracl/tree/cff161bad6364548b361b63938a988db23f60c2a) and extract the contents of the main folder in `src/externals/Miracl`. Then, continue with steps 2 and 3.
+Please note that downloading this project as ZIP file will yield compilation errors, since the Miracl library is included as external project. To solve this, download the Miracl sources in commit version `cff161b` (found [here](https://github.com/CertiVox/Miracl/tree/cff161bad6364548b361b63938a988db23f60c2a) and extract the contents of the main folder in `src/externals/Miracl`. Then, continue with steps 2 and 3.
 
 ### Executing the Code
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This code is provided as an experimental implementation for testing purposes and
 ### Requirements
 ---
 
-* A **Linux distribution** of your choice (the code was developed and tested with recent versions of [Ubuntu](http://www.ubuntu.com/)).
+* A **Linux distribution** of your choice (the code was developed and tested with recent versions of [Ubuntu](https://www.ubuntu.com/)).
 * **Required packages:**
   * [`g++`](https://packages.debian.org/testing/g++)
   * [`make`](https://packages.debian.org/testing/make)
@@ -40,7 +40,7 @@ This code is provided as an experimental implementation for testing purposes and
 
 3. Call `make` in the root directory to compile all dependencies, tests, and examples and create the executables: **psi.exe** (used for benchmarking) and **demo.exe** (a small demonstrator for intersecting email addresses).
 
-Please note that downloading this project as ZIP file will yield compilation errors, since the Miracl library is included as external project. To solve this, download the Miracl sources in commit version `cff161b` (found [here](https://github.com/CertiVox/Miracl/tree/cff161bad6364548b361b63938a988db23f60c2a) and extract the contents of the main folder in `src/externals/Miracl`. Then, continue with steps 2 and 3.
+Please note that downloading this project as ZIP file will yield compilation errors, since the Miracl library is included as external project. To solve this, download the Miracl sources in commit version `cff161b` (found at [Miracl commit cff161b](https://github.com/CertiVox/Miracl/tree/cff161bad6364548b361b63938a988db23f60c2a) and extract the contents of the main folder in `src/externals/Miracl`. Then, continue with steps 2 and 3.
 
 ### Executing the Code
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ By *Benny Pinkas, Thomas Schneider and Michael Zohner* in USENIX Security Sympos
   * the Diffie-Hellman-based PSI protocol of [5]
   * the OT-based PSI protocol of [3]
 
-This code is provided as a experimental implementation for testing purposes and should not be used in a productive environment. We cannot guarantee security and correctness.
+This code is provided as an experimental implementation for testing purposes and should not be used in a productive environment. We cannot guarantee security and correctness.
 
 ### Requirements
 ---


### PR DESCRIPTION
Replaced incorrect article "a" with "an" in front of "experimental" in the README file.